### PR TITLE
Make sure `random_delay` is initialized before use

### DIFF
--- a/custom_components/spothinta/coordinator.py
+++ b/custom_components/spothinta/coordinator.py
@@ -67,10 +67,11 @@ class SpotHintaDataUpdateCoordinator(DataUpdateCoordinator[SpotHintaData]):
             return SpotHintaData(energy_today=self.current_data)
 
         if self.current_data is None or now.hour >= 11:
+            random_delay = randint(0, 120)
+
             # We want to get the prices for tomorrow, but we want to avoid
             # having all instances of the integration polling at the same second.
             if self.current_data is not None and now.minute == 0 and now.second == 0:
-                random_delay = randint(0, 120)
                 next_update_at = now + timedelta(seconds=random_delay)
                 _LOGGER.debug("Getting prices for tomorrow in %s seconds", random_delay)
 


### PR DESCRIPTION
If e.g. a timeout happens when fetching data with old data being available too, the `random_delay` variable used in the retrying is not initialized, and the following error is logged and the retrying is stopped until Home Assistant is restarted:

```
2023-10-28 15:03:20.278 ERROR (MainThread) [custom_components.spothinta] Unexpected error fetching spothinta_FI data: cannot access local variable 'random_delay' where it is not associated with a value
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/spothinta_api/spothinta.py", line 81, in _request
    response = await self.session.request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client.py", line 560, in _request
    await resp.start(conn)
  File "/usr/local/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 899, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/streams.py", line 616, in read
    await self._waiter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/spothinta_api/spothinta.py", line 80, in _request
    async with async_timeout.timeout(self.request_timeout):
  File "/usr/local/lib/python3.11/site-packages/async_timeout/__init__.py", line 141, in __aexit__
    self._do_exit(exc_type)
  File "/usr/local/lib/python3.11/site-packages/async_timeout/__init__.py", line 228, in _do_exit
    raise asyncio.TimeoutError
TimeoutError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/config/custom_components/spothinta/coordinator.py", line 84, in _async_update_data
    self.current_data = await self.spothinta.energy_prices(self.region)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/spothinta_api/spothinta.py", line 132, in energy_prices
    data = await self._request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/spothinta_api/spothinta.py", line 91, in _request
    raise SpotHintaConnectionError(
spothinta_api.exceptions.SpotHintaConnectionError: Timeout occurred while connecting to the API.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 290, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/spothinta/coordinator.py", line 90, in _async_update_data
    now + timedelta(minutes=5) + timedelta(seconds=random_delay)
                                                   ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'random_delay' where it is not associated with a value
```