### PR TITLE
Disable pylint E1123 `unexpected-keyword-arg`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ignore = [
 disable= [
     "duplicate-code",
     "format",
+    "unexpected-keyword-arg",
 ]
 
 [tool.pylint.SIMILARITIES]


### PR DESCRIPTION
Home Assistant has it disabled, and updating `homeassistant` from `2023.12.0` triggers errors it.